### PR TITLE
Common: add when condition to check if SELinux is enabled

### DIFF
--- a/mongodb/roles/common/tasks/main.yml
+++ b/mongodb/roles/common/tasks/main.yml
@@ -37,7 +37,8 @@
     proto: tcp
     setype: mongod_port_t
     state: present
-
+  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
+    
 - name: Create the mongod user
   user: name=mongod comment="MongoD"
 


### PR DESCRIPTION
This condition allows you to install mongoDB on servers with disabled SELinux. 